### PR TITLE
Changes DOCKER_IMAGE to 0.1.7-lite to pickup streamlined image

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -5,7 +5,7 @@
 SCRIPT_DIR="$(cd $(dirname $0); pwd -P)"
 SRC_DIR="$(cd "${SCRIPT_DIR}/terraform" ; pwd -P)"
 
-DOCKER_IMAGE="ibmgaragecloud/cli-tools:0.1.6"
+DOCKER_IMAGE="ibmgaragecloud/cli-tools:0.1.7-lite"
 
 helpFunction()
 {


### PR DESCRIPTION
Also picks up bump to v0.1.7 which installed a newer version of the IBM Cloud terraform provider that should fix the Cloudant issue we've been having

(ibm-garage-cloud/planning#220)