### PR TITLE
Updates stage0

### DIFF
--- a/terraform/stages/stage0.tf
+++ b/terraform/stages/stage0.tf
@@ -1,5 +1,3 @@
 terraform {
-  backend "local" {
-    path = "./state/terraform.tfstate"
-  }
+  required_version = "> 0.12.0"
 }

--- a/terraform/stages/variables.tf
+++ b/terraform/stages/variables.tf
@@ -112,3 +112,9 @@ variable "name_prefix" {
   description = "Prefix name that should be used for the cluster and services. If not provided then resource_group_name will be used"
   default     = ""
 }
+
+variable "TF_VERSION" {
+  type        = string
+  description = "The version of terraform that should be used"
+  default     = "0.12"
+}

--- a/terraform/templates/stage0/backend-local.tf
+++ b/terraform/templates/stage0/backend-local.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_version = "> 0.12.0"
+  backend "local" {
+    path = "./state/terraform.tfstate"
+  }
+}


### PR DESCRIPTION
- Adds required_version greater than 0.12.0
- Removes local backend since it is the default
- Adds `backend-local.tf` in the templates folder to preserve the state path that was used
- Adds `TF_VERSION` to variables.tf with default value of '0.12'

ibm-garage-cloud/planning#383