### PR TITLE
Updates stages to use new module versions

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -5,7 +5,7 @@
 SCRIPT_DIR="$(cd $(dirname $0); pwd -P)"
 SRC_DIR="$(cd "${SCRIPT_DIR}/terraform" ; pwd -P)"
 
-DOCKER_IMAGE="ibmgaragecloud/cli-tools:0.1.8"
+DOCKER_IMAGE="ibmgaragecloud/cli-tools:0.1.11"
 
 helpFunction()
 {

--- a/terraform/stages/catalog/stage1-olm.tf
+++ b/terraform/stages/catalog/stage1-olm.tf
@@ -1,9 +1,0 @@
-module "dev_software_olm_release" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//self-managed/software/operator-lifecycle-manager?ref=v2.2.16"
-
-  cluster_config_file      = module.dev_cluster.config_file_path
-  cluster_version          = module.dev_cluster.version
-  cluster_type             = var.cluster_type
-  olm_version              = "0.14.1"
-
-}

--- a/terraform/stages/stage1-cluster.tf
+++ b/terraform/stages/stage1-cluster.tf
@@ -1,5 +1,5 @@
 module "dev_cluster" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//cloud-managed/cluster/ibmcloud?ref=v2.5.0"
+  source = "github.com/ibm-garage-cloud/terraform-ibm-container-platform.git?ref=v1.7.0"
 
   resource_group_name     = var.resource_group_name
   cluster_name            = var.cluster_name
@@ -7,7 +7,6 @@ module "dev_cluster" {
   public_vlan_id          = var.public_vlan_id
   vlan_datacenter         = var.vlan_datacenter
   cluster_region          = var.vlan_region
-  kubeconfig_download_dir = var.user_home_dir
   cluster_machine_type    = var.cluster_machine_type
   cluster_worker_count    = var.cluster_worker_count
   cluster_hardware        = var.cluster_hardware
@@ -15,5 +14,5 @@ module "dev_cluster" {
   cluster_exists          = var.cluster_exists
   ibmcloud_api_key        = var.ibmcloud_api_key
   name_prefix             = var.name_prefix
-  is_vpc                  = false
+  is_vpc                  = var.vpc_cluster == "true"
 }

--- a/terraform/stages/stage1-namespaces.tf
+++ b/terraform/stages/stage1-namespaces.tf
@@ -1,7 +1,7 @@
 module "dev_cluster_namespaces" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//generic/cluster/namespaces?ref=v2.3.3"
+  source = "github.com/ibm-garage-cloud/terraform-cluster-namespace.git?ref=v1.0.0"
 
-  cluster_type             = module.dev_cluster.type
+  cluster_type             = module.dev_cluster.type_code
   cluster_config_file_path = module.dev_cluster.config_file_path
   tls_secret_name          = module.dev_cluster.tls_secret_name
   tools_namespace          = var.tools_namespace
@@ -9,11 +9,10 @@ module "dev_cluster_namespaces" {
 }
 
 module "dev_sre_namespace" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//generic/cluster/namespaces?ref=v2.3.3"
+  source = "github.com/ibm-garage-cloud/terraform-cluster-namespace.git?ref=v2.0.0"
 
-  cluster_type             = module.dev_cluster.type
+  cluster_type             = module.dev_cluster.type_code
   cluster_config_file_path = module.dev_cluster.config_file_path
   tls_secret_name          = module.dev_cluster.tls_secret_name
-  tools_namespace          = var.sre_namespace
-  release_namespaces       = []
+  name                     = var.sre_namespace
 }

--- a/terraform/stages/stage1-olm.tf
+++ b/terraform/stages/stage1-olm.tf
@@ -1,0 +1,8 @@
+module "dev_software_olm" {
+  source = "github.com/ibm-garage-cloud/terraform-software-olm.git?ref=v1.1.0"
+
+  cluster_config_file      = module.dev_cluster.config_file_path
+  cluster_version          = ""
+  cluster_type             = module.dev_cluster.type_code
+  olm_version              = "0.14.1"
+}

--- a/terraform/stages/stage2-artifactory.tf
+++ b/terraform/stages/stage2-artifactory.tf
@@ -1,5 +1,5 @@
 module "dev_serviceaccount_artifactory" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//generic/cluster/serviceaccount?ref=v2.2.0"
+  source = "github.com/ibm-garage-cloud/terraform-cluster-serviceaccount.git?ref=v1.2.0"
 
   cluster_type             = var.cluster_type
   namespace                = module.dev_cluster_namespaces.tools_namespace_name
@@ -8,13 +8,13 @@ module "dev_serviceaccount_artifactory" {
   sscs                     = ["anyuid", "privileged"]
 }
 
-module "dev_tools_artifactory_release" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//generic/tools/artifactory_release?ref=v2.3.1"
+module "dev_tools_artifactory" {
+  source = "github.com/ibm-garage-cloud/terraform-tools-artifactory.git?ref=v1.2.0"
 
   cluster_type             = var.cluster_type
   service_account          = module.dev_serviceaccount_artifactory.name
+  releases_namespace       = module.dev_serviceaccount_artifactory.namespace
   cluster_ingress_hostname = module.dev_cluster.ingress_hostname
   cluster_config_file      = module.dev_cluster.config_file_path
-  releases_namespace       = module.dev_cluster_namespaces.tools_namespace_name
   tls_secret_name          = module.dev_cluster.tls_secret_name
 }

--- a/terraform/stages/stage2-dashboard.tf
+++ b/terraform/stages/stage2-dashboard.tf
@@ -1,10 +1,10 @@
-module "dev_tools_dashboard_release" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//generic/tools/developerdashboard_release?ref=v2.4.4"
+module "dev_tools_dashboard" {
+  source = "github.com/ibm-garage-cloud/terraform-tools-dashboard.git?ref=v1.2.0"
 
   cluster_ingress_hostname = module.dev_cluster.ingress_hostname
   cluster_config_file      = module.dev_cluster.config_file_path
-  cluster_type             = var.cluster_type
-  releases_namespace       = module.dev_cluster_namespaces.tools_namespace_name
+  cluster_type             = module.dev_cluster.type_code
   tls_secret_name          = module.dev_cluster.tls_secret_name
+  releases_namespace       = module.dev_cluster_namespaces.tools_namespace_name
   image_tag                = "1.0.31"
 }

--- a/terraform/stages/stage2-jaeger.tf
+++ b/terraform/stages/stage2-jaeger.tf
@@ -1,5 +1,5 @@
-module "dev_tools_argocd" {
-  source = "github.com/ibm-garage-cloud/terraform-tools-argocd.git?ref=v2.4.0"
+module "dev_tools_jaeger" {
+  source = "github.com/ibm-garage-cloud/terraform-tools-jaeger.git?ref=v1.3.0"
 
   cluster_config_file = module.dev_cluster.config_file_path
   cluster_type        = module.dev_cluster.type_code
@@ -7,5 +7,5 @@ module "dev_tools_argocd" {
   operator_namespace  = module.dev_software_olm.target_namespace
   app_namespace       = module.dev_cluster_namespaces.tools_namespace_name
   ingress_subdomain   = module.dev_cluster.ingress_hostname
-  name                = "argocd"
+  name                = "jaeger"
 }

--- a/terraform/stages/stage2-jenkins.tf
+++ b/terraform/stages/stage2-jenkins.tf
@@ -1,11 +1,10 @@
-module "dev_tools_jenkins_release" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//generic/tools/jenkins_release?ref=v2.3.0"
+module "dev_tools_jenkins" {
+  source = "github.com/ibm-garage-cloud/terraform-tools-jenkins.git?ref=v1.1.1"
 
   cluster_ingress_hostname = module.dev_cluster.ingress_hostname
   cluster_config_file      = module.dev_cluster.config_file_path
-  cluster_type             = var.cluster_type
-  tools_namespace          = module.dev_cluster_namespaces.tools_namespace_name
-  ci_namespace             = module.dev_cluster_namespaces.release_namespaces[0]
+  cluster_type             = module.dev_cluster.type
   tls_secret_name          = module.dev_cluster.tls_secret_name
   server_url               = module.dev_cluster.server_url
+  tools_namespace          = module.dev_cluster_namespaces.tools_namespace_name
 }

--- a/terraform/stages/stage2-pactbroker.tf
+++ b/terraform/stages/stage2-pactbroker.tf
@@ -1,5 +1,5 @@
 module "dev_tools_pactbroker_release" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//generic/tools/pactbroker_release?ref=v2.3.0"
+  source = "github.com/ibm-garage-cloud/terraform-tools-pactbroker.git?ref=v1.2.0"
 
   cluster_ingress_hostname                      = module.dev_cluster.ingress_hostname
   cluster_config_file                           = module.dev_cluster.config_file_path

--- a/terraform/stages/stage2-sonarqube.tf
+++ b/terraform/stages/stage2-sonarqube.tf
@@ -1,20 +1,28 @@
-module "dev_serviceaccount_sonarqube" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//generic/cluster/serviceaccount?ref=v2.2.8"
-
-  cluster_type             = var.cluster_type
-  namespace                = module.dev_cluster_namespaces.tools_namespace_name
-  cluster_config_file_path = module.dev_cluster.config_file_path
-  service_account_name     = "sonarqube"
-  sscs                     = ["anyuid", "privileged"]
-}
-
-module "dev_tools_sonarqube_release" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//generic/tools/sonarqube_release?ref=v2.3.0"
+module "dev_tools_sonarqube" {
+  source = "github.com/ibm-garage-cloud/terraform-tools-sonarqube.git?ref=v1.3.0"
 
   cluster_type             = var.cluster_type
   cluster_ingress_hostname = module.dev_cluster.ingress_hostname
   cluster_config_file      = module.dev_cluster.config_file_path
   releases_namespace       = module.dev_cluster_namespaces.tools_namespace_name
-  service_account_name     = module.dev_serviceaccount_sonarqube.name
+  service_account_name     = "sonarqube"
   tls_secret_name          = module.dev_cluster.tls_secret_name
+  postgresql               = {
+    external      = false
+    username      = ""
+    password      = ""
+    hostname      = ""
+    port          = ""
+    database_name = ""
+  }
+}
+
+module "dev_serviceaccount_sonarqube" {
+  source = "github.com/ibm-garage-cloud/terraform-cluster-serviceaccount.git?ref=v1.3.0"
+
+  cluster_type             = var.cluster_type
+  cluster_config_file_path = module.dev_cluster.config_file_path
+  namespace                = module.dev_tools_sonarqube.namespace
+  service_account_name     = module.dev_tools_sonarqube.service_account
+  sscs                     = ["anyuid", "privileged"]
 }

--- a/terraform/stages/stage2-swagger.tf
+++ b/terraform/stages/stage2-swagger.tf
@@ -1,9 +1,12 @@
-module "dev_tools_swagger_release" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//generic/tools/swagger_editor?ref=v2.3.0"
+module "dev_tools_swagger" {
+  source = "github.com/ibm-garage-cloud/terraform-tools-swaggereditor.git?ref=v1.2.0"
 
   cluster_ingress_hostname = module.dev_cluster.ingress_hostname
   cluster_config_file      = module.dev_cluster.config_file_path
-  cluster_type             = var.cluster_type
-  releases_namespace       = module.dev_cluster_namespaces.tools_namespace_name
+  cluster_type             = module.dev_cluster.type_code
   tls_secret_name          = module.dev_cluster.tls_secret_name
+  releases_namespace       = module.dev_cluster_namespaces.tools_namespace_name
+  image_tag                = "v3.8.0"
+  enable_sso               = true
+  chart_version            = "1.3.0"
 }

--- a/terraform/stages/stage2-tekton.tf
+++ b/terraform/stages/stage2-tekton.tf
@@ -1,16 +1,16 @@
 module "dev_tools_tekton_release" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//generic/tools/tekton_release?ref=v2.4.6"
+  source = "github.com/ibm-garage-cloud/terraform-tools-tekton.git?ref=v1.2.0"
 
-  cluster_type             = module.dev_cluster.type
+  cluster_type             = module.dev_cluster.type_code
   cluster_config_file_path = module.dev_cluster.config_file_path
   cluster_ingress_hostname = module.dev_cluster.ingress_hostname
   tools_namespace          = module.dev_cluster_namespaces.tools_namespace_name
 }
 
 module "dev_tools_tekton_resources" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//generic/tools/tekton_resources?ref=v2.4.6"
+  source = "github.com/ibm-garage-cloud/terraform-tools-tekton-resources.git?ref=v1.1.0"
 
-  cluster_type             = module.dev_cluster.type
+  cluster_type             = module.dev_cluster.type_code
   cluster_config_file_path = module.dev_cluster.config_file_path
   tekton_namespace         = module.dev_tools_tekton_release.namespace
   resource_namespace       = module.dev_cluster_namespaces.tools_namespace_name

--- a/terraform/stages/stage3-logdna.tf
+++ b/terraform/stages/stage3-logdna.tf
@@ -1,21 +1,22 @@
 module "dev_serviceaccount_logdna-agent" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//generic/cluster/serviceaccount?ref=v2.2.2"
+  source = "github.com/ibm-garage-cloud/terraform-cluster-serviceaccount.git?ref=v1.3.0"
 
   cluster_type             = var.cluster_type
   cluster_config_file_path = module.dev_cluster.config_file_path
-  namespace                = module.dev_sre_namespace.tools_namespace_name
+  namespace                = module.dev_sre_namespace.name
   service_account_name     = "logdna-agent"
   sscs                     = ["privileged"]
 }
 
 module "dev_infrastructure_logdna" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//cloud-managed/services/logdna?ref=v2.2.12"
+  source = "github.com/ibm-garage-cloud/terraform-ibm-logdna.git?ref=v1.1.0"
 
   resource_group_name      = module.dev_cluster.resource_group_name
   resource_location        = module.dev_cluster.region
   cluster_type             = var.cluster_type
   cluster_config_file_path = module.dev_cluster.config_file_path
   service_account_name     = module.dev_serviceaccount_logdna-agent.name
+  namespace                = module.dev_serviceaccount_logdna-agent.namespace
   name_prefix              = var.name_prefix
-  namespace                = module.dev_sre_namespace.tools_namespace_name
+  exists                   = var.logdna_exists == "true"
 }

--- a/terraform/stages/stage3-sysdig.tf
+++ b/terraform/stages/stage3-sysdig.tf
@@ -1,11 +1,12 @@
 module "dev_infrastructure_sysdig" {
-  source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//cloud-managed/services/sysdig?ref=v2.4.3"
+  source = "github.com/ibm-garage-cloud/terraform-ibm-sysdig.git?ref=398-remove-dependencies"
 
   resource_group_name      = module.dev_cluster.resource_group_name
   resource_location        = module.dev_cluster.region
   cluster_config_file_path = module.dev_cluster.config_file_path
   cluster_type             = var.cluster_type
   name_prefix              = var.name_prefix
-  namespace                = module.dev_sre_namespace.tools_namespace_name
+  namespace                = module.dev_sre_namespace.name
   tags                     = [module.dev_cluster.tag]
+  exists                   = var.sysdig_exists == "true"
 }

--- a/terraform/stages/variables.tf
+++ b/terraform/stages/variables.tf
@@ -114,7 +114,25 @@ variable "name_prefix" {
 }
 
 variable "TF_VERSION" {
-  type        = string
+  type = string
   description = "The version of terraform that should be used"
-  default     = "0.12"
+  default = "0.12"
+}
+
+variable "vpc_cluster" {
+  type        = string
+  description = "Flag indicating if the cluster is vpc"
+  default     = "false"
+}
+
+variable "logdna_exists" {
+  type        = string
+  description = "Flag indicating that the logdna instance already exists"
+  default     = "false"
+}
+
+variable "sysdig_exists" {
+  type        = string
+  description = "Flag indicating that the sysdig instance already exists"
+  default     = "false"
 }


### PR DESCRIPTION
- Adds TF_VERSION to variables.tf for IBM Private Catalog support
- Adds vpc_cluster to variables.tf to provide to the `is_vpc` variable on the cluster module (the value is a string to support Schematics/IBM Private Catalog limitations on supported variable types)
- Updates the source reference for stage1-cluster.tf to point to the separated module repository

ibm-garage-cloud/planning#337