### PR TITLE
Pipeline updates

### DIFF
--- a/.github/workflows/notify.yaml
+++ b/.github/workflows/notify.yaml
@@ -1,0 +1,18 @@
+name: Notify
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        slug: ["ibm-garage-cloud/cloudnative-toolkit"]
+
+    steps:
+      - name: Repository dispatch ${{matrix.slug}}
+        run: |
+          curl -XPOST -u "${{ secrets.USERNAME}}:${{secrets.TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${{matrix.slug}}/dispatches --data '{"event_type": "released"}'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,23 @@
+name: Release
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+          config-name: release-drafter.yaml
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,5 @@ jobs:
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
           config-name: release-drafter.yaml
-          publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -1,10 +1,8 @@
-name: Verify and release
+name: Verify PR
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -89,20 +87,3 @@ jobs:
 #            diff $PWD/cluster-state/before $PWD/cluster-state/after
 #            exit 1
 #          fi
-
-  release:
-    #    if: ${{ github.event_name == 'push' }}
-    needs: verify
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' }}
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
-        with:
-          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-          config-name: release-drafter.yaml
-          publish: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Only run the verification process on a PR, not on push to master (for now)
- Release using TOKEN instead of GITHUB_TOKEN so that events can trigger downstream processes
- Adds notify pipeline to trigger a repository dispatch event on the cloudnative-toolkit repo