### PR TITLE
Bumps tekton module to v1.3.4

### DIFF
--- a/terraform/stages/stage2-jenkins.tf
+++ b/terraform/stages/stage2-jenkins.tf
@@ -1,5 +1,5 @@
 module "dev_tools_jenkins" {
-  source = "github.com/ibm-garage-cloud/terraform-tools-jenkins.git?ref=v1.3.4"
+  source = "github.com/ibm-garage-cloud/terraform-tools-jenkins.git?ref=v1.4.3"
 
   cluster_ingress_hostname = module.dev_cluster.ingress_hostname
   cluster_config_file      = module.dev_cluster.config_file_path

--- a/terraform/stages/stage2-jenkins.tf
+++ b/terraform/stages/stage2-jenkins.tf
@@ -1,5 +1,5 @@
 module "dev_tools_jenkins" {
-  source = "github.com/ibm-garage-cloud/terraform-tools-jenkins.git?ref=v1.4.2"
+  source = "github.com/ibm-garage-cloud/terraform-tools-jenkins.git?ref=v1.3.4"
 
   cluster_ingress_hostname = module.dev_cluster.ingress_hostname
   cluster_config_file      = module.dev_cluster.config_file_path

--- a/terraform/stages/stage2-jenkins.tf
+++ b/terraform/stages/stage2-jenkins.tf
@@ -1,5 +1,5 @@
 module "dev_tools_jenkins" {
-  source = "github.com/ibm-garage-cloud/terraform-tools-jenkins.git?ref=v1.4.3"
+  source = "github.com/ibm-garage-cloud/terraform-tools-jenkins.git?ref=v1.4.2"
 
   cluster_ingress_hostname = module.dev_cluster.ingress_hostname
   cluster_config_file      = module.dev_cluster.config_file_path

--- a/terraform/stages/stage2-tekton.tf
+++ b/terraform/stages/stage2-tekton.tf
@@ -1,5 +1,5 @@
 module "dev_tools_tekton_release" {
-  source = "github.com/ibm-garage-cloud/terraform-tools-tekton.git?ref=v1.3.3"
+  source = "github.com/ibm-garage-cloud/terraform-tools-tekton.git?ref=v1.3.4"
 
   cluster_type             = module.dev_cluster.type_code
   cluster_config_file_path = module.dev_cluster.config_file_path


### PR DESCRIPTION
- Reverts to using comunity version of the Tekton operator

ibm-garage-cloud/planning#450