### PR TITLE
Fixes cloud-native tile creation logic

### DIFF
--- a/.tile/tiles/cloudnative-toolkit/build.sh
+++ b/.tile/tiles/cloudnative-toolkit/build.sh
@@ -38,7 +38,7 @@ mkdir -p "${WORKSPACE_DIR}"
 
 SRC_DIR="./terraform"
 
-ENVIRONMENT_TFVARS="${SRC_DIR}/settings/environment.tfvars"
+ENVIRONMENT_TFVARS="${SRC_DIR}/settings/environment-ibmcloud.tfvars"
 TFVARS="${WORKSPACE_DIR}/terraform.tfvars"
 cat "${ENVIRONMENT_TFVARS}" > "${TFVARS}"
 


### PR DESCRIPTION
- Use renamed environment-ibmcloud.tfvars instead of the old file name