### PR TITLE
Bumps logdna and sysdig modules to v2.3.0

### DIFF
--- a/.tile/tiles/cloudnative-toolkit/offering.json
+++ b/.tile/tiles/cloudnative-toolkit/offering.json
@@ -93,6 +93,14 @@
               "hidden": false
             },
             {
+              "key": "logdna_region",
+              "type": "string",
+              "default_value": "",
+              "description": "The region where the logdna instance will be/has been provisioned. If not provided this will default to the overall region",
+              "required": false,
+              "hidden": false
+            },
+            {
               "key": "provision_logdna",
               "type": "string",
               "default_value": "false",
@@ -105,6 +113,14 @@
               "type": "string",
               "default_value": "",
               "description": "The name of the existing sysdig instance to which the cluster should be connected",
+              "required": false,
+              "hidden": false
+            },
+            {
+              "key": "sysdig_region",
+              "type": "string",
+              "default_value": "",
+              "description": "The region where the sysdig instance will be/has been provisioned. If not provided this will default to the overall region",
               "required": false,
               "hidden": false
             },

--- a/launch.sh
+++ b/launch.sh
@@ -5,7 +5,7 @@
 SCRIPT_DIR="$(cd $(dirname $0); pwd -P)"
 SRC_DIR="$(cd "${SCRIPT_DIR}/terraform" ; pwd -P)"
 
-DOCKER_IMAGE="ibmgaragecloud/cli-tools:0.6.0-lite"
+DOCKER_IMAGE="ibmgaragecloud/cli-tools:0.7.0-lite"
 
 helpFunction()
 {

--- a/terraform/settings/environment-ibmcloud.tfvars
+++ b/terraform/settings/environment-ibmcloud.tfvars
@@ -44,6 +44,9 @@ vpc_zone_names=""
 # you are not provisioning the LogDNA instance and would like to bind the cluster to an existing instance
 # then this value is REQUIRED
 #logdna_name=""
+# The region where the LogDNA instance has been/will be provisioned. If the value is not provided then the value
+# will default to the `region`
+#logdna_region=""
 
 # This flag is used to indicate that a Sysdig instance should be provisioned. The default is "false"
 # if this value is not provided.
@@ -53,6 +56,9 @@ vpc_zone_names=""
 # you are not provisioning the Sysdig instance and would like to bind the cluster to an existing instance
 # then this value is REQUIRED
 #sysdig_name=""
+# The region where the Sysdig instance has been/will be provisioned. If the value is not provided then the value
+# will default to the `region`
+#sysdig_region=""
 
 # This flag is used to indicate that a Object Storage instance should be provisioned. The default is "false"
 # if this value is not provided.

--- a/terraform/stages/stage3-logdna.tf
+++ b/terraform/stages/stage3-logdna.tf
@@ -1,9 +1,10 @@
 module "dev_infrastructure_logdna" {
-  source = "github.com/ibm-garage-cloud/terraform-ibm-logdna.git?ref=v2.2.0"
+  source = "github.com/ibm-garage-cloud/terraform-ibm-logdna.git?ref=v2.3.0"
 
-  cluster_id               = module.dev_cluster.name
+  cluster_name             = module.dev_cluster.name
+  cluster_id               = module.dev_cluster.id
   resource_group_name      = module.dev_cluster.resource_group_name
-  resource_location        = module.dev_cluster.region
+  resource_location        = var.logdna_region != "" ? var.logdna_region : module.dev_cluster.region
   cluster_type             = module.dev_cluster.type_code
   cluster_config_file_path = module.dev_cluster.config_file_path
   namespace                = module.dev_sre_namespace.name

--- a/terraform/stages/stage3-sysdig.tf
+++ b/terraform/stages/stage3-sysdig.tf
@@ -1,9 +1,10 @@
 module "dev_infrastructure_sysdig" {
-  source = "github.com/ibm-garage-cloud/terraform-ibm-sysdig.git?ref=v2.2.0"
+  source = "github.com/ibm-garage-cloud/terraform-ibm-sysdig.git?ref=v2.3.0"
 
-  cluster_id               = module.dev_cluster.name
+  cluster_name             = module.dev_cluster.name
+  cluster_id               = module.dev_cluster.id
   resource_group_name      = module.dev_cluster.resource_group_name
-  resource_location        = module.dev_cluster.region
+  resource_location        = var.sysdig_region != "" ? var.sysdig_region : module.dev_cluster.region
   cluster_config_file_path = module.dev_cluster.config_file_path
   cluster_type             = module.dev_cluster.type_code
   name_prefix              = var.name_prefix

--- a/terraform/stages/variables.tf
+++ b/terraform/stages/variables.tf
@@ -145,6 +145,12 @@ variable "logdna_name" {
   default     = ""
 }
 
+variable "logdna_region" {
+  type        = string
+  description = "The region where the logdna instance will be/has been provisioned. If not provided this will default to the overall region"
+  default     = ""
+}
+
 variable "provision_sysdig" {
   type        = string
   description = "Flag indicating that a sysdig instance should be provisioned"
@@ -154,6 +160,12 @@ variable "provision_sysdig" {
 variable "sysdig_name" {
   type        = string
   description = "The name of the sysdig instance. This is particularly used for an existing sysdig instance. If not provided the name will be derived from the name_prefix/resource_group"
+  default     = ""
+}
+
+variable "sysdig_region" {
+  type        = string
+  description = "The region where the sysdig instance will be/has been provisioned. If not provided this will default to the overall region"
   default     = ""
 }
 


### PR DESCRIPTION
- Updates logdna and sysdig to use cluster id and resource id when binding the service to prevent cross-region issues
- Bumps cli-tools image to v0.7.0-lite to get v1.9.0 of ibm terraform provider (requirement of logdna and sysdig versions)
- Adds logdna_region and sysdig_region variables to allow logdna and sysdig to be in a different region than the cluster