### PR TITLE
Updates namespace to v2.6.0

### DIFF
--- a/terraform/stages/stage1-namespaces.tf
+++ b/terraform/stages/stage1-namespaces.tf
@@ -1,5 +1,5 @@
 module "dev_tools_namespace" {
-  source = "github.com/ibm-garage-cloud/terraform-k8s-namespace.git?ref=v2.5.2"
+  source = "github.com/ibm-garage-cloud/terraform-k8s-namespace.git?ref=v2.6.0"
 
   cluster_type             = module.dev_cluster.type_code
   cluster_config_file_path = module.dev_cluster.config_file_path
@@ -8,7 +8,7 @@ module "dev_tools_namespace" {
 }
 
 module "dev_sre_namespace" {
-  source = "github.com/ibm-garage-cloud/terraform-k8s-namespace.git?ref=v2.5.2"
+  source = "github.com/ibm-garage-cloud/terraform-k8s-namespace.git?ref=v2.6.0"
 
   cluster_type             = module.dev_cluster.type_code
   cluster_config_file_path = module.dev_cluster.config_file_path


### PR DESCRIPTION
- Removes deprecated --export flag

ibm-garage-cloud/planning#512