### PR TITLE
Bumps argocd module to v2.9.0 for key-protect plugin

### DIFF
--- a/terraform/stages-ocp4/stage2-argocd.tf
+++ b/terraform/stages-ocp4/stage2-argocd.tf
@@ -1,5 +1,5 @@
 module "dev_tools_argocd" {
-  source = "github.com/ibm-garage-cloud/terraform-tools-argocd.git?ref=v2.8.0"
+  source = "github.com/ibm-garage-cloud/terraform-tools-argocd.git?ref=v2.9.0"
 
   cluster_config_file = module.dev_cluster.config_file_path
   cluster_type        = module.dev_cluster.type_code

--- a/terraform/stages/stage2-argocd.tf
+++ b/terraform/stages/stage2-argocd.tf
@@ -1,5 +1,5 @@
 module "dev_tools_argocd" {
-  source = "github.com/ibm-garage-cloud/terraform-tools-argocd.git?ref=v2.8.0"
+  source = "github.com/ibm-garage-cloud/terraform-tools-argocd.git?ref=v2.9.0"
 
   cluster_config_file = module.dev_cluster.config_file_path
   cluster_type        = module.dev_cluster.type_code


### PR DESCRIPTION
- Updates to v2.9.0 of the argocd module to automatically install the key-protect plugin