### PR TITLE
Updates to ocp4 install process for usability

### DIFF
--- a/.github/scripts/update-modules.sh
+++ b/.github/scripts/update-modules.sh
@@ -33,7 +33,7 @@ ls "${REPO_DIR}/terraform" | while read -r dir; do
         continue
       fi
 
-      git_slug=$(echo "$source" | sed -E 's~github.com/(.*).git.*~\1~g')
+      git_slug=$(echo "$source" | sed -E 's~github.com/(.*)\?.*~\1~g' | sed "s/.git//g")
 
       git_release_url="https://api.github.com/repos/${git_slug}/releases/latest"
 

--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [ocp4_vpc, ocp44_vpc]
+        platform: [ocp44_vpc]
       #      max-parallel: 1
       fail-fast: false
 

--- a/credentials.template
+++ b/credentials.template
@@ -1,7 +1,11 @@
 # Add the values for the Credentials to access the IBM Cloud
-# Instuctions to access this information is in the README.MD
-classic.username=<CLASSIC_USERNAME>
-classic.api.key=<CLASSIC_API_KEY>
-ibmcloud.api.key=<IBMCLOUD_API_KEY>
-login.user=<OCP USER>
-login.password=<OCP PASSWORD>
+# Instructions to access this information can be found in the README.MD
+classic.username=""
+classic.api.key=""
+ibmcloud.api.key=""
+# Authentication to OCP can either be performed with username/password or token
+# If token is provided it will take precedence
+login.user=""
+login.password=""
+login.token=""
+server.url=""

--- a/launch.sh
+++ b/launch.sh
@@ -5,7 +5,7 @@
 SCRIPT_DIR="$(cd $(dirname $0); pwd -P)"
 SRC_DIR="$(cd "${SCRIPT_DIR}/terraform" ; pwd -P)"
 
-DOCKER_IMAGE="ibmgaragecloud/cli-tools:0.7.0-lite"
+DOCKER_IMAGE="ibmgaragecloud/cli-tools:0.8.0-lite"
 
 helpFunction()
 {
@@ -50,14 +50,10 @@ if [[ -f "${ENV}.properties" ]]; then
     CLASSIC_USERNAME=$(prop 'classic.username')
     LOGIN_USER=$(prop 'login.user')
     LOGIN_PASSWORD=$(prop 'login.password')
+    LOGIN_TOKEN=$(prop 'login.token')
+    SERVER_URL=$(prop 'server.url')
 else
     helpFunction "The ${ENV}.properties file is not found."
-fi
-
-# Print helpFunction in case parameters are empty
-if [[ -z "${IBMCLOUD_API_KEY}" ]]
-then
-    helpFunction "Some of the credentials values are empty. "
 fi
 
 SUFFIX=$(echo $(basename ${SCRIPT_DIR}) | base64 | sed -E "s/[^a-zA-Z0-9_.-]//g" | sed -E "s/.*(.{5})/\1/g")
@@ -80,6 +76,8 @@ ${DOCKER_CMD} run -itd --name ${CONTAINER_NAME} \
    -e TF_VAR_ibmcloud_api_key="${IBMCLOUD_API_KEY}" \
    -e TF_VAR_login_user="${LOGIN_USER}" \
    -e TF_VAR_login_password="${LOGIN_PASSWORD}" \
+   -e TF_VAR_login_token="${LOGIN_TOKEN}" \
+   -e TF_VAR_server_url="${SERVER_URL}" \
    -e IBMCLOUD_API_KEY="${IBMCLOUD_API_KEY}" \
    -e IAAS_CLASSIC_USERNAME="${CLASSIC_USERNAME}" \
    -e IAAS_CLASSIC_API_KEY="${CLASSIC_API_KEY}" \

--- a/terraform/runTerraform.sh
+++ b/terraform/runTerraform.sh
@@ -59,10 +59,15 @@ else
 
   if [[ -f "${ENVIRONMENT_TFVARS}" ]]; then
     CLUSTER_NAME=$(grep -E "^cluster_name" "${ENVIRONMENT_TFVARS}" | sed -E "s/^cluster_name=\"(.*)\".*/\1/g")
+    SERVER_URL=$(grep -E "^server_url" "${ENVIRONMENT_TFVARS}" | sed -E "s/^server_url=\"(.*)\".*/\1/g")
   fi
 
   if [[ -z "${CLUSTER_NAME}" ]]; then
     CLUSTER_NAME="ocp-cluster"
+  fi
+
+  if [[ -z "${SERVER_URL}" ]]; then
+    SERVER_URL="${TF_VAR_server_url}"
   fi
 
   CLUSTER_EXISTS="true"
@@ -182,12 +187,16 @@ fi
 if [[ "${CLUSTER_EXISTS}" == "false" ]]; then
     echo -e "  - Create a new \033[1;33m${CLUSTER_TYPE}\033[0m cluster instance named \033[1;33m${CLUSTER_NAME}\033[0m${MANAGED_BY}"
 else
-    echo -e "  - Use an existing \033[1;33m${CLUSTER_TYPE}\033[0m cluster instance named \033[1;33m${CLUSTER_NAME}\033[0m${MANAGED_BY}"
+    if [[ -n "${SERVER_URL}" ]]; then
+      echo -e "  - Use an existing \033[1;33m${CLUSTER_TYPE}\033[0m cluster instance at ${SERVER_URL}"
+    else
+      echo -e "  - Use an existing \033[1;33m${CLUSTER_TYPE}\033[0m cluster instance named \033[1;33m${CLUSTER_NAME}\033[0m${MANAGED_BY}"
+    fi
     echo ""
     echo -e "\033[1;31mBefore configuring the environment the following namespaces and their contents will be destroyed: tools and ibm-observe\033[0m"
 fi
 
-if [[ "o" ==  "${CLUSTER_MANAGEMENT}" ]]; then
+if [[ "o" == "${CLUSTER_MANAGEMENT}" ]]; then
 	STAGES_DIRECTORY="stages-ocp4"
 else
 	STAGES_DIRECTORY="stages"

--- a/terraform/runTerraform.sh
+++ b/terraform/runTerraform.sh
@@ -57,7 +57,10 @@ if [[ "${CLUSTER_MANAGEMENT}" == "i" ]]; then
 else
   ENVIRONMENT_TFVARS="${SRC_DIR}/settings/environment-ocp.tfvars"
 
-  CLUSTER_NAME=$(grep -E "^cluster_name" "${ENVIRONMENT_TFVARS}" | sed -E "s/^cluster_name=\"(.*)\".*/\1/g")
+  if [[ -f "${ENVIRONMENT_TFVARS}" ]]; then
+    CLUSTER_NAME=$(grep -E "^cluster_name" "${ENVIRONMENT_TFVARS}" | sed -E "s/^cluster_name=\"(.*)\".*/\1/g")
+  fi
+
   if [[ -z "${CLUSTER_NAME}" ]]; then
     CLUSTER_NAME="ocp-cluster"
   fi
@@ -102,7 +105,11 @@ mkdir -p "${WORKSPACE_DIR}"
 
 TFVARS="${WORKSPACE_DIR}/terraform.tfvars"
 
-cat "${ENVIRONMENT_TFVARS}" > "${TFVARS}"
+rm -f "${TFVARS}"
+
+if [[ -f "${ENVIRONMENT_TFVARS}" ]]; then
+  cat "${ENVIRONMENT_TFVARS}" >> "${TFVARS}"
+fi
 cat "${SRC_DIR}/settings/vlan.tfvars" >> "${TFVARS}"
 echo "" >> "${TFVARS}"
 cp "${SRC_DIR}"/scripts-workspace/* "${WORKSPACE_DIR}"

--- a/terraform/settings/environment-ocp.tfvars
+++ b/terraform/settings/environment-ocp.tfvars
@@ -1,1 +1,0 @@
-server_url="<server url>"

--- a/terraform/stages-ocp4/stage1-cluster.tf
+++ b/terraform/stages-ocp4/stage1-cluster.tf
@@ -1,7 +1,8 @@
 module "dev_cluster" {
-  source = "github.com/ibm-garage-cloud/terraform-k8s-ocp-cluster?ref=v2.3.2"
+  source = "github.com/ibm-garage-cloud/terraform-k8s-ocp-cluster?ref=v2.3.4"
 
   login_user              = var.login_user
   login_password          = var.login_password
+  login_token             = var.login_token
   server_url              = var.server_url
 }

--- a/terraform/stages-ocp4/variables.tf
+++ b/terraform/stages-ocp4/variables.tf
@@ -13,11 +13,19 @@ variable "sre_namespace" {
 variable "login_user" {
   type        = string
   description = "The username to log in to openshift"
+  default     = ""
 }
 
 variable "login_password" {
   type        = string
   description = "The password to log in to openshift"
+  default     = ""
+}
+
+variable "login_token" {
+  type        = string
+  description = "The token used to log in to openshift"
+  default     = ""
 }
 
 variable "server_url" {


### PR DESCRIPTION
- Add support for ocp login with token
- Moves server.url into credentials.template/credentials.properties since token and server url should go together
- Removes unnecessary environment-ocp file from terraform/settings